### PR TITLE
fix: DeferredCommand constructor

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/command/DeferredCommand.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/command/DeferredCommand.java
@@ -8,11 +8,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -26,9 +23,8 @@ import java.util.function.Supplier;
  *
  * @author Suchir Ryali - X BOTS 19448
  */
-public class DeferredCommand implements Command {
+public class DeferredCommand extends CommandBase {
     private final Supplier<Command> supplier;
-    private final Set<Subsystem> requirements;
     @Nullable
     private Command command;
 
@@ -45,10 +41,9 @@ public class DeferredCommand implements Command {
      */
     public DeferredCommand(@NonNull Supplier<Command> supplier, @Nullable List<Subsystem> requirements) {
         this.supplier = Objects.requireNonNull(supplier);
-        // Using List argument for Java 8 compat.
-        this.requirements = requirements != null
-                ? Collections.unmodifiableSet(new HashSet<>(requirements))
-                : Collections.emptySet();
+        // Using List argument instead of Set for Java 8 compat.
+        if (requirements != null)
+            m_requirements.addAll(requirements);
     }
 
     @Override
@@ -71,11 +66,6 @@ public class DeferredCommand implements Command {
     @Override
     public boolean isFinished() {
         return command == null || command.isFinished();
-    }
-
-    @Override
-    public Set<Subsystem> getRequirements() {
-        return requirements;
     }
 
     @Override

--- a/core/src/main/java/com/seattlesolvers/solverslib/command/DeferredCommand.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/command/DeferredCommand.java
@@ -1,12 +1,16 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
 package com.seattlesolvers.solverslib.command;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.arcrobotics.ftclib.command.Command;
-import com.arcrobotics.ftclib.command.Subsystem;
-
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -17,18 +21,34 @@ import java.util.function.Supplier;
  * command, like building a new trajectory in the middle of auto. If this command is interrupted, it
  * will cancel the command.
  *
+ * <p>Note that the supplier <i>must</i> create a new Command each call. For selecting one of a
+ * preallocated set of commands, use {@link SelectCommand}.
+ *
  * @author Suchir Ryali - X BOTS 19448
  */
-
 public class DeferredCommand implements Command {
     private final Supplier<Command> supplier;
     private final Set<Subsystem> requirements;
     @Nullable
     private Command command;
-    
-    public DeferredCommand(@NonNull Supplier<Command> supplier, @Nullable Set<Subsystem> requirements) {
+
+    /**
+     * Creates a new DeferredCommand that directly runs the supplied command when initialized, and
+     * ends when it ends. Useful for lazily creating commands when the DeferredCommand is initialized,
+     * such as if the supplied command depends on runtime state. The {@link Supplier} will be called
+     * each time this command is initialized. The Supplier <i>must</i> create a new Command each call.
+     *
+     * @param supplier     The command supplier
+     * @param requirements The command requirements. This is a {@link List} to prevent accidental
+     *                     omission of command requirements. Use {@link Arrays#asList} to easily construct requirements.
+     *                     Passing null or an empty list will result in no requirements.
+     */
+    public DeferredCommand(@NonNull Supplier<Command> supplier, @Nullable List<Subsystem> requirements) {
         this.supplier = Objects.requireNonNull(supplier);
-        this.requirements = requirements != null ? requirements : Collections.emptySet();
+        // Using List argument for Java 8 compat.
+        this.requirements = requirements != null
+                ? Collections.unmodifiableSet(new HashSet<>(requirements))
+                : Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
- Change `DeferredCommand` constructor to take a `List<Subsystem>` for Java 8 compact. (`Set.of()` does not exist, so users can use `Arrays.asList()` instead)
- Add some docs from WPILib's `DeferredCommand`
- Extend `CommandBase` in `DeferredCommand` for consistency with other commands in the library
 
## Did this PR introduce a breaking change?
- `DeferredCommand` constructor takes `List<Subsystem>` instead of `Set<Subsystem>`