### PR TITLE
bug fix ConcurrentModificationException when using cancelAll method in the CommandScheduler

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/command/CommandScheduler.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/command/CommandScheduler.java
@@ -366,7 +366,10 @@ public final class CommandScheduler {
      * Cancels all commands that are currently scheduled.
      */
     public void cancelAll() {
-        for (Command command : m_scheduledCommands.keySet()) {
+        // Make a copy of the scheduled commands
+        List<Command> toCancel = new ArrayList<>(m_scheduledCommands.keySet());
+        // Now safely cancel each one
+        for (Command command : toCancel) {
             cancel(command);
         }
     }


### PR DESCRIPTION
# Pull Requests

when using the cancelAll method in the CommandScheduler I got a ConcurrentModificationException

![WhatsApp Image 2025-08-06 at 20 38 19](https://github.com/user-attachments/assets/f8403b66-0a92-41c5-b351-4b85720771fd)

this pr fixes it by putting the commands in a different list before looping over it

## What kind of change does this PR introduce?
* Fix

## Did this PR introduce a breaking change?
* No