### PR TITLE
feat: Debouncer and GenericDebouncer

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/util/Debouncer.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/util/Debouncer.java
@@ -31,12 +31,12 @@ public class Debouncer {
      *
      * @param debounceRising Debounce time on the rising edge in seconds
      * @param debounceFalling Debounce time on the falling edge in seconds
-     * @param baseline If it is initially rising (true) or falling (false)
+     * @param initial If it is initially true or falling false
      */
-    public Debouncer(double debounceRising, double debounceFalling, boolean baseline) {
+    public Debouncer(double debounceRising, double debounceFalling, boolean initial) {
         this.debounceRising = debounceRising;
         this.debounceFalling = debounceFalling;
-        reset(baseline);
+        reset(initial);
     }
 
     /**

--- a/core/src/main/java/com/seattlesolvers/solverslib/util/GenericDebouncer.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/util/GenericDebouncer.java
@@ -1,0 +1,61 @@
+package com.seattlesolvers.solverslib.util;
+
+import java.util.Objects;
+
+/**
+ * A generic debouncer that works across type.
+ * Useful if you have multiple values, like a color sensor to determine red, green, or blue.
+ * Or if you needed to detect April Tags.
+ *
+ * @author Daniel - FTC 7854
+ */
+public class GenericDebouncer<T> {
+    private double debounce;
+
+    private long previousTime;
+    private T state;
+    private T lastInput;
+
+    /**
+     * Creates a fully specified debouncer
+     *
+     * @param debounce Debounce time
+     * @param initial What the initial value is
+     */
+    public GenericDebouncer(double debounce, T initial) {
+        this.debounce = debounce;
+        reset(initial);
+    }
+
+    /**
+     * Applies the debouncer to the input stream.
+     *
+     * @param input The measured value
+     * @return The debounced value
+     */
+    public T calculate(T input) {
+        if (Objects.equals(input, lastInput)) {
+            lastInput = input;
+            previousTime = System.nanoTime();
+        }
+
+        // This will still work before the first input change
+        if (System.nanoTime() - previousTime >= debounce * 1e6) {
+            state = input;
+        }
+
+        return state;
+    }
+
+    /**
+     * Resets the debouncer to a state.
+     * Useful if you know for sure something has changed and don't want to wait.
+     *
+     * @param state The new state of the debouncer
+     */
+    public void reset(T state) {
+        this.previousTime = 0;
+        this.state = state;
+        this.lastInput = state;
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?
* It introduces the `Debouncer` class, much like WPILib's `Debouncer`. If you use the same constructors found in the [WPILib implementation](https://github.com/wpilibsuite/allwpilib/blob/b8d6bc2eb1b6cea10d1179939114d041945e172a/wpimath/src/main/java/edu/wpi/first/math/filter/Debouncer.java), it will work the same.
* There is also an additional constructor that allows for much more versatility, allowing you to set the rising edge debounce, falling edge debounce, and the initial value.
* This also fixes a bug in WPILib that I found. Say the debounce time was 0.3s. If I had a measurement at 0.1s of `false` and one at 0.5s of `true` with no measurements in between, WPILib would simply set the debounced value to be `true` as the gap is 0.4s. However, what we really want is for it to stay `true` for at least 0.3s. This is a minor issue as loop times are very short anyways.
* Added GenericDebouncer which is a version that can work across any type. For example, you could have a color sensor that classifies green, purple, or nothing and you want a debouncer for it. This is how we would use this in our spindexer. You could also be detecting April Tags and want to make sure you're detecting it correctly.

## Did this PR introduce a breaking change?
* No