### PR TITLE
add getCurrentCommandName to SequentialCommandGroup

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/command/SequentialCommandGroup.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/command/SequentialCommandGroup.java
@@ -103,4 +103,7 @@ public class SequentialCommandGroup extends CommandGroupBase {
         return m_runWhenDisabled;
     }
 
+    public String getCurrentCommandName(){
+        return m_commands.get(m_currentCommandIndex).getName();
+    }
 }


### PR DESCRIPTION
# Pull Requests
add getCurrentCommandName to SequentialCommandGroup
this can be used to log which command in the SequentialCommandGroup is currently running to make it easier to debug

## What kind of change does this PR introduce?
* Feature

## Did this PR introduce a breaking change?
* No