### PR TITLE
Add `preRun()` to CommandOpMode.java

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/command/CommandOpMode.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/command/CommandOpMode.java
@@ -47,6 +47,7 @@ public abstract class CommandOpMode extends LinearOpMode {
             while (opModeInInit()) {
                 initialize_loop();
             }
+            preRun();
             while (opModeIsActive()) {
                 run();
             }
@@ -60,6 +61,11 @@ public abstract class CommandOpMode extends LinearOpMode {
     }
 
     public abstract void initialize();
+
+    /**
+     * Runs before the OpMode is active and after init.
+     */
+    public void preRun() {}
 
     /**
      * Runs at the end (when opMode is no longer active) of CommandOpMode


### PR DESCRIPTION
# Add `preRun()` to CommandOpMode.java
## What kind of change does this PR introduce?
* Feature


## Did this PR introduce a breaking change?
* No

## Description
Adds a `preRun()` method to CommandOpMode that is called once after init and before run