### PR TITLE
Fix: Corrected velocity measurement in `CascadeController` 

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/controller/CascadeController.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/controller/CascadeController.java
@@ -4,6 +4,7 @@ public class CascadeController extends Controller {
     private final Controller primary;
     private final Controller secondary;
     private double velMeasuredValue;
+    private double prevMeasuredValue;
     private double velSetPoint;
 
     public CascadeController(Controller primary, Controller secondary) {
@@ -14,24 +15,21 @@ public class CascadeController extends Controller {
     @Override
     protected double calculateOutput(double pv) {
         prevErrorVal = errorVal_p;
+        prevMeasuredValue = measuredValue;
 
         double currentTimeStamp = (double) System.nanoTime() / 1E9;
         if (lastTimeStamp == 0) lastTimeStamp = currentTimeStamp;
         period = currentTimeStamp - lastTimeStamp;
-        lastTimeStamp = currentTimeStamp;
 
-        if (measuredValue == pv) {
-            errorVal_p = setPoint - measuredValue;
-        } else {
-            errorVal_p = setPoint - pv;
+        if (measuredValue != pv) {
             measuredValue = pv;
         }
+        errorVal_p = setPoint - measuredValue;
 
         if (Math.abs(period) > 1E-6) {
-            velMeasuredValue = (errorVal_p - prevErrorVal) / period;
-        } else {
-            velMeasuredValue = 0;
-        }
+            velMeasuredValue = (measuredValue - prevMeasuredValue) / period;
+            lastTimeStamp = currentTimeStamp;
+        } 
 
         errorVal_v = velSetPoint - velMeasuredValue;
 
@@ -50,7 +48,11 @@ public class CascadeController extends Controller {
         setPoint = psp;
         velSetPoint = vsp;
         errorVal_p = setPoint - measuredValue;
-        velMeasuredValue = (errorVal_p - prevErrorVal) / period;
+        velMeasuredValue = (measuredValue - prevMeasuredValue) / period;
         errorVal_v = velSetPoint - velMeasuredValue;
+    }
+
+    public double getMeasuredVel() {
+        return velMeasuredValue;
     }
 }


### PR DESCRIPTION
## What fix
This PR fixes the velocity calculation in the `CascadeController` class. The previous implementation incorrectly calculated measured velocity as the derivative of position error rather than the derivative of measured position itself, resulting in inaccurate velocity feedback in the cascade controller loop.

## Previous error (fixed)
The original code computed velocity as `velMeasuredValue = (errorVal_p - prevErrorVal) / period;`, which is mathematically incorrect since velocity should represent the rate of change of position, not error. This fix implements the correct calculation by tracking the previous measured position and computing `velMeasuredValue = (measuredValue - prevMeasuredValue) / period;`.

## Fix implementation
The implementation introduces a `prevMeasuredValue` field to maintain position history, updates the timestamp only when the period is valid (greater than 1E-6) for improved efficiency, applies the corrected formula to the `setSetPoints()` method, and adds a new `getMeasuredVel()` getter for public access to the measured velocity. These changes improve accuracy of velocity feedback, ensure physical consistency with the mathematical definition of velocity, and enhance the overall stability of cascade control behavior.

## Possible breaks
This fix could brake some previous tuning because of it change measured value of velocity controller (`private Controller secondary`) as above explained.

CLOSES #35 