### PR TITLE
Don't call preRun when stop is pressed during init phase

### DIFF
--- a/core/src/main/java/com/seattlesolvers/solverslib/command/CommandOpMode.java
+++ b/core/src/main/java/com/seattlesolvers/solverslib/command/CommandOpMode.java
@@ -47,9 +47,11 @@ public abstract class CommandOpMode extends LinearOpMode {
             while (opModeInInit()) {
                 initialize_loop();
             }
-            preRun();
-            while (opModeIsActive()) {
-                run();
+            if (opModeIsActive()) {
+                preRun();
+                while (opModeIsActive()) {
+                    run();
+                }
             }
         } finally {
             try {


### PR DESCRIPTION
# Pull Requests

Small fix for #34 to only call `preRun()` if the start button was pressed. When stop is pressed during init, neither `preRun()` nor `run()` should be called.

## What kind of change does this PR introduce?
* Fix

## Did this PR introduce a breaking change?
* No